### PR TITLE
Feat: Modify achievement window

### DIFF
--- a/Invaders-SDP.iml
+++ b/Invaders-SDP.iml
@@ -6,7 +6,7 @@
       <sourceFolder url="file://$MODULE_DIR$/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
-    <orderEntry type="jdk" jdkName="21" jdkType="JavaSDK" />
+    <orderEntry type="jdk" jdkName="17" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -78,22 +78,28 @@ public class DrawManagerImpl extends DrawManager {
     public static void drawAchievement(final Screen screen, String achievementText) {
         int width = screen.getWidth() / 4;
         int height = screen.getHeight() / 16;
+        int fontWidth;
 
         backBufferGraphics.setColor(Color.white);
-        backBufferGraphics.drawRect(screen.getWidth() - width - 8, screen.getHeight() - height - 20, width, height);
+        backBufferGraphics.drawRect(screen.getWidth() - width - 3, screen.getHeight() - height - 18, width, height);
 
         backBufferGraphics.setColor(Color.white);
         backBufferGraphics.setFont(fontRegular);
         if(achievementText.length() < 14){
-            backBufferGraphics.drawString(achievementText, screen.getWidth() - width, screen.getHeight() - 35);
+            fontWidth = fontRegularMetrics.stringWidth(achievementText);
+            backBufferGraphics.drawString(achievementText, screen.getWidth() - width / 2 - fontWidth / 2, screen.getHeight() - 35);
         }
         else if(achievementText.length() < 27){
-            backBufferGraphics.drawString(achievementText.substring(0,13), screen.getWidth() - width, screen.getHeight() - 45);
-            backBufferGraphics.drawString(achievementText.substring(13), screen.getWidth() - width, screen.getHeight() - 25);
+            fontWidth = fontRegularMetrics.stringWidth(achievementText.substring(0,13));
+            backBufferGraphics.drawString(achievementText.substring(0,13), screen.getWidth() - width / 2 - fontWidth / 2, screen.getHeight() - 43);
+            fontWidth = fontRegularMetrics.stringWidth(achievementText.substring(13));
+            backBufferGraphics.drawString(achievementText.substring(13), screen.getWidth() - width/2 - fontWidth / 2, screen.getHeight() - 25);
         }
         else{
-            backBufferGraphics.drawString(achievementText.substring(0,13), screen.getWidth() - width, screen.getHeight() - 45);
-            backBufferGraphics.drawString(achievementText.substring(13,26), screen.getWidth() - width, screen.getHeight() - 25);
+            fontWidth = fontRegularMetrics.stringWidth(achievementText.substring(0,13));
+            backBufferGraphics.drawString(achievementText.substring(0,13), screen.getWidth() - width / 2 - fontWidth / 2, screen.getHeight() - 43);
+            fontWidth = fontRegularMetrics.stringWidth(achievementText.substring(13,25)+"...");
+            backBufferGraphics.drawString(achievementText.substring(13,25)+"...", screen.getWidth() - width / 2 - fontWidth / 2, screen.getHeight() - 25);
         }
     }
 

--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -74,6 +74,8 @@ public class DrawManagerImpl extends DrawManager {
      *            Screen to draw on.
      * @param achievementText
      *            Accomplished achievement text.
+     *
+     * by Jo Minseo - HUD team
      */
     public static void drawAchievement(final Screen screen, String achievementText) {
         int width = screen.getWidth() / 4;
@@ -83,6 +85,7 @@ public class DrawManagerImpl extends DrawManager {
         backBufferGraphics.setColor(Color.white);
         backBufferGraphics.drawRect(screen.getWidth() - width - 3, screen.getHeight() - height - 18, width, height);
 
+        //Modify the location of the window and the text - Jo Minseo/HUD team
         backBufferGraphics.setColor(Color.white);
         backBufferGraphics.setFont(fontRegular);
         if(achievementText.length() < 14){

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -206,10 +206,8 @@ public class GameScreen extends Screen {
 					this.ship.moveLeft();
 				}
 				if (inputManager.isKeyDown(KeyEvent.VK_SPACE))
-					if (this.ship.shoot(this.bullets)) {
-						Achievement.achieve("sentence");
+					if (this.ship.shoot(this.bullets))
 						this.bulletsShot++;
-					}
 			}
 
 			if (this.enemyShipSpecial != null) {

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -206,8 +206,10 @@ public class GameScreen extends Screen {
 					this.ship.moveLeft();
 				}
 				if (inputManager.isKeyDown(KeyEvent.VK_SPACE))
-					if (this.ship.shoot(this.bullets))
+					if (this.ship.shoot(this.bullets)) {
+						Achievement.achieve("sentence");
 						this.bulletsShot++;
+					}
 			}
 
 			if (this.enemyShipSpecial != null) {


### PR DESCRIPTION
## What
This PR modify achievement window. It includes the following changes:
- Modify the position of the achievement window downward
- Modify the line spacing of text in the achievement window to be narrow
- Modify the text of the achievement window to always be centered

## Why
Not to interfere with the dividing line and the player.

## Related Issue
Closes #19

## How to Test
1.  Run the core class
2. Check if the achievement window doesn't interfere the dividing line and the player when you shoot
3. Check if the achievement text is in the center of the achievement window
4. Check if it works if you change it to another string instead of "sentence"

## Screenshots
![achievement2](https://github.com/user-attachments/assets/83c4e267-83b8-46a7-bbbf-ca0970d7242c)

## Additional Information
I didn't increase the size because there was space, so I modify the position of the achievement window downward
Achievement text changed from left to center alignment.