### PR TITLE
Feature/29 adjust single player UI

### DIFF
--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -19,7 +19,7 @@ public class DrawManagerImpl extends DrawManager {
         int xPosition = screen.getWidth() / 2;
         int yPosition = 25;
 
-        backBufferGraphics.drawString(levelText, xPosition - fontRegularMetrics.stringWidth(levelText) / 2, yPosition);
+        backBufferGraphics.drawString(levelText, xPosition - fontRegularMetrics.stringWidth(levelText) / 2, yPosition); // edit by jesung ko - TeamHUD
     } // Lee Hyun Woo - level
     
     public static void drawAttackSpeed(final Screen screen, final double attackSpeed) {
@@ -65,9 +65,19 @@ public class DrawManagerImpl extends DrawManager {
         int playTimeSeconds = playTime % 60;
         String playTimeString = String.format("%d"+"m "+"%d"+"s", playTimeMinutes, playTimeSeconds);
         int xPosition = (screen.getWidth() * 4) / 6; // position 4/6
-        backBufferGraphics.drawString(playTimeString, xPosition - fontRegularMetrics.stringWidth(playTimeString) / 2, 25);
+        backBufferGraphics.drawString(playTimeString, xPosition - fontRegularMetrics.stringWidth(playTimeString) / 2, 25); // edit by jesung ko - TeamHUD
     }
 
+    /**
+     * Draws the player's score on the screen.
+     * The score is displayed at the 2/6 position of the screen width.
+     *
+     * @param screen
+     *          The screen to draw on.
+     * @param score
+     *          The current score to display.
+     * by jesung Ko - TeamHUD
+     */
     public static void drawScore2(final Screen screen, final int score) {
         String scoreString = "Score: " + score;
         backBufferGraphics.setFont(fontRegular);

--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -64,7 +64,8 @@ public class DrawManagerImpl extends DrawManager {
         int playTimeMinutes = playTime / 60;
         int playTimeSeconds = playTime % 60;
         String playTimeString = String.format("%d"+"m "+"%d"+"s", playTimeMinutes, playTimeSeconds);
-        backBufferGraphics.drawString(playTimeString, screen.getWidth() / 2 - 20, 25);
+        int xPosition = (screen.getWidth() * 4) / 6; // position 4/6
+        backBufferGraphics.drawString(playTimeString, xPosition - fontRegularMetrics.stringWidth(playTimeString) / 2, 25);
     }
 
     /**

--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -16,10 +16,10 @@ public class DrawManagerImpl extends DrawManager {
         backBufferGraphics.setFont(fontRegular);
         backBufferGraphics.setColor(Color.WHITE);
 
-        int xPosition = screen.getWidth() - fontRegularMetrics.stringWidth(levelText) - 100;
+        int xPosition = screen.getWidth() / 2;
         int yPosition = 25;
 
-        backBufferGraphics.drawString(levelText, xPosition, yPosition);
+        backBufferGraphics.drawString(levelText, xPosition - fontRegularMetrics.stringWidth(levelText) / 2, yPosition);
     } // Lee Hyun Woo - level
     
     public static void drawAttackSpeed(final Screen screen, final double attackSpeed) {

--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -136,7 +136,12 @@ public class DrawManagerImpl extends DrawManager {
         backBufferGraphics.setFont(fontRegular);
         backBufferGraphics.setColor(Color.WHITE);
         String remainingEnemiesString = "Enemies: " + remainingEnemies;
-        backBufferGraphics.drawString(remainingEnemiesString, 140, screen.getHeight() - 25);
+        int textWidth = fontRegularMetrics.stringWidth(remainingEnemiesString);
+
+        int x = (screen.getWidth() - textWidth) / 2;
+        int y = screen.getHeight() - 25;
+
+        backBufferGraphics.drawString(remainingEnemiesString, x, y);
     } // by SeungYun
 
     /**

--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -68,6 +68,13 @@ public class DrawManagerImpl extends DrawManager {
         backBufferGraphics.drawString(playTimeString, xPosition - fontRegularMetrics.stringWidth(playTimeString) / 2, 25);
     }
 
+    public static void drawScore2(final Screen screen, final int score) {
+        String scoreString = "Score: " + score;
+        backBufferGraphics.setFont(fontRegular);
+        backBufferGraphics.setColor(Color.WHITE);
+        int xPosition = (screen.getWidth() * 2) / 6; // 2/6 지점
+        backBufferGraphics.drawString(scoreString, xPosition - fontRegularMetrics.stringWidth(scoreString) / 2, 25);
+    }
     /**
      * Show accomplished achievement
      *

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -288,7 +288,8 @@ public class GameScreen extends Screen {
 		this.itemManager.drawItems(); //by Enemy team
 
 		// Interface.
-		drawManager.drawScore(this, this.score);
+//		drawManager.drawScore(this, this.score);
+		DrawManagerImpl.drawScore2(this,this.score);
 		drawManager.drawLives(this, this.lives);
 		drawManager.drawHorizontalLine(this, SEPARATION_LINE_HEIGHT - 1);
 		DrawManagerImpl.drawRemainingEnemies(this, getRemainingEnemies()); // by HUD team SeungYun

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -288,8 +288,8 @@ public class GameScreen extends Screen {
 		this.itemManager.drawItems(); //by Enemy team
 
 		// Interface.
-//		drawManager.drawScore(this, this.score);
-		DrawManagerImpl.drawScore2(this,this.score);
+//		drawManager.drawScore(this, this.score); // by jesung ko - TeamHUD
+		DrawManagerImpl.drawScore2(this,this.score); // by jesung ko - TeamHUD
 		drawManager.drawLives(this, this.lives);
 		drawManager.drawHorizontalLine(this, SEPARATION_LINE_HEIGHT - 1);
 		DrawManagerImpl.drawRemainingEnemies(this, getRemainingEnemies()); // by HUD team SeungYun


### PR DESCRIPTION
## What
This PR adjusts the positioning of UI elements (score, level, time) as previously described. It includes dynamic positioning using fontRegularMetrics to ensure the elements adapt to different screen sizes rather than using static positioning.
- Adjusted score, level, and time elements to appear at the 2/6, 3/6, and 4/6 points of the x-axis, respectively.
- Used fontRegularMetrics for dynamic positioning instead of hardcoded static values.

## Why
This change aims to reduce the gap between the UI of the two-player mode and the single-player mode.

## Related Issue
Closes #29 

## How to Test
1. Start the application locally.
2. Verify that the score, level, and time elements are correctly positioned at the 2/6, 3/6, and 4/6 points on the x-axis, respectively.
3. Resize the window to check that the elements remain aligned dynamically.

## Screenshots
![image](https://github.com/user-attachments/assets/ba141974-b2f9-4c6a-a846-a42e57bf0afd)

