### PR TITLE
feat: replace the attack speed and movement speed position

### DIFF
--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -25,15 +25,15 @@ public class DrawManagerImpl extends DrawManager {
     public static void drawAttackSpeed(final Screen screen, final double attackSpeed) {
         backBufferGraphics.setFont(fontRegular);
         backBufferGraphics.setColor(Color.WHITE);
-        String attackSpeedText = String.format("AS: %.2f ", attackSpeed);
-        backBufferGraphics.drawString(attackSpeedText, 10, screen.getHeight() - 25);
+        String attackSpeedText = String.format("AS : %.2f ", attackSpeed);
+        backBufferGraphics.drawString(attackSpeedText, 10, screen.getHeight() - 15);
     }
 
     public static void drawSpeed(final Screen screen, final int speed) {
         String speedString = "MS : " + speed;
         backBufferGraphics.setColor(Color.WHITE);
         backBufferGraphics.setFont(fontRegular);
-        backBufferGraphics.drawString(speedString, 85, screen.getHeight() - 25);
+        backBufferGraphics.drawString(speedString, 10, screen.getHeight() - 35);
     }
 
     public void drawLivesWithHeart(final Screen screen, final int lives) {


### PR DESCRIPTION
## What
This PR adjusts the positioning of UI elements (attack speed, move speed) as previously described.
- Adjusted attack speed and move speed elements position.

## Why
This change aims to reduce the gap between the UI of the two-player mode and the single-player mode.

## Related Issue
Closes #31 

## How to Test
1. Start the application locally.
2. Verify that the attack speed and move speed are correctly positioned side by side.

## Screenshots
<img width="742" alt="image" src="https://github.com/user-attachments/assets/48c2bcd8-cd30-4681-9f1a-0469868584da">