### PR TITLE
feat: Change background color around green lines

### DIFF
--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -159,6 +159,20 @@ public class DrawManagerImpl extends DrawManager {
                 positionY + 1);
     }
 
+    /**
+     * Draws a filled rectangle with specified color at given coordinates.
+     *
+     * @param x
+     *            The x-coordinate of the rectangle's top-left corner.
+     * @param y
+     *            The y-coordinate of the rectangle's top-left corner.
+     * @param width
+     *            The width of the rectangle.
+     * @param height
+     *            The height of the rectangle.
+     * @param color
+     *            The color to fill the rectangle.
+     */
     public static void drawRect(final int x, final int y, final int width, final int height, final Color color) {
         backBufferGraphics.setColor(color);
         backBufferGraphics.fillRect(x, y, width, height);

--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -158,4 +158,9 @@ public class DrawManagerImpl extends DrawManager {
         backBufferGraphics.drawLine(0, positionY + 1, screen.getWidth(),
                 positionY + 1);
     }
+
+    public static void drawRect(final int x, final int y, final int width, final int height, final Color color) {
+        backBufferGraphics.setColor(color);
+        backBufferGraphics.fillRect(x, y, width, height);
+    } // by Saeum Jung - TeamHUD
 }

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -426,6 +426,9 @@ public class GameScreen extends Screen {
 		this.backgroundMoveRight = false;
 		this.backgroundMoveLeft = false;
 
+		DrawManagerImpl.drawRect(0, 0, this.width, SEPARATION_LINE_HEIGHT, Color.BLACK);
+		DrawManagerImpl.drawRect(0, this.height - 70, this.width, 70, Color.BLACK); // by Saeum Jung - TeamHUD
+
 		drawManager.drawEntity(this.ship, this.ship.getPositionX(),
 				this.ship.getPositionY());
 		if (this.enemyShipSpecial != null)


### PR DESCRIPTION
## What
This PR adds the changes for users' better gameplay. It includes the following changes:
- Modify background color above the top green line to black.
- Modify background color below the bottom green line to black.
- Modify the draw method of the GameScreen class to draw black rectangle.
- Add the drawRect method of the DrawManagerImpl class to use method in GameScreen.


## Why
This feature is to provide a better gaming environment for users with a neat screen.

## Related Issue
Closes #42 

## How to Test
1. Start the application locally.
2. Check if the background color above the top green line and below the bottom green line is black.

## Screenshots
![image](https://github.com/user-attachments/assets/098c1387-e8cd-46c2-b92e-a0c033057588)
