### PR TITLE
feat : Feature add the status information of 2p

### DIFF
--- a/src/HUDTeam/DrawManagerImpl.java
+++ b/src/HUDTeam/DrawManagerImpl.java
@@ -1,6 +1,7 @@
 package HUDTeam;
 
 import engine.DrawManager;
+import screen.GameScreen;
 import screen.Screen;
 import entity.Entity;
 import java.awt.Color;
@@ -181,4 +182,63 @@ public class DrawManagerImpl extends DrawManager {
         backBufferGraphics.setColor(color);
         backBufferGraphics.fillRect(x, y, width, height);
     } // by Saeum Jung - TeamHUD
+
+    /**
+     * Draws 2P's lives on screen.
+     *
+     * @param screen
+     *            Screen to draw on.
+     * @param livestwo two
+     *            2P's lives
+     *
+     * by Lee HyunWoo - TeamHUD
+     */
+    public static void drawLives2P(final Screen screen, final int livestwo) {
+        backBufferGraphics.setFont(fontRegular);
+        backBufferGraphics.setColor(Color.WHITE);
+        Entity heart = new Entity(0, 0, 13 * 2, 8 * 2, Color.BLUE) {
+
+        };
+        heart.setSpriteType(SpriteType.Heart);
+
+        int heartWidth = 13 * 2;
+        int startingXPosition = screen.getWidth() - (heartWidth * livestwo) - 20;
+
+        for (int i = 0; i < livestwo; i++)
+            drawEntity(heart, startingXPosition + 30 * i, 10);
+    }
+
+    /**
+     * Draws 2P's bulletSpeed on screen.
+     *
+     * @param screen
+     *            Screen to draw on.
+     * @param bulletSpeed two
+     *            2P's bulletSpeed
+     *
+     * by Lee HyunWoo - TeamHUD
+     */
+    public static void drawBulletSpeed2P(final Screen screen, final int bulletSpeed) {
+        backBufferGraphics.setFont(fontRegular);
+        backBufferGraphics.setColor(Color.WHITE);
+        String bulletSpeedText = String.format("BS : %d px/f ", bulletSpeed);
+        backBufferGraphics.drawString(bulletSpeedText, 500, screen.getHeight() - 15);
+    }
+
+    /**
+     * Draws 2P's speed on screen.
+     *
+     * @param screen
+     *            Screen to draw on.
+     * @param speed two
+     *            2P's speed
+     *
+     * by Lee HyunWoo - TeamHUD
+     */
+    public static void drawSpeed2P(final Screen screen, final double speed) {
+        String speedString = "MS : " + speed;
+        backBufferGraphics.setColor(Color.WHITE);
+        backBufferGraphics.setFont(fontRegular);
+        backBufferGraphics.drawString(speedString, 500, screen.getHeight() - 35);
+    }
 }

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -247,7 +247,7 @@ public class DrawManager {
 	 * @param positionY
 	 *            Coordinates for the upper side of the image.
 	 */
-	public void drawEntity(final Entity entity, final int positionX,
+	public static void drawEntity(final Entity entity, final int positionX,
 						   final int positionY) {
 
 		try {

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -481,8 +481,7 @@ public class GameScreen extends Screen {
 //		drawManager.drawScore(this, this.scoreManager.getAccumulatedScore());    //clove -> edit by jesung ko - TeamHUD(to udjust score)
 //		drawManager.drawScore(this, this.score); // by jesung ko - TeamHUD
 		DrawManagerImpl.drawScore2(this,this.scoreManager.getAccumulatedScore()); // by jesung ko - TeamHUD
-//		drawManager.drawLives(this, this.lives);
-		DrawManagerImpl.drawLives2P(this, this.lives);
+		drawManager.drawLives(this, this.lives);
 		drawManager.drawHorizontalLine(this, SEPARATION_LINE_HEIGHT - 1);
 		DrawManagerImpl.drawRemainingEnemies(this, getRemainingEnemies()); // by HUD team SeungYun
 		DrawManagerImpl.drawLevel(this, this.level);
@@ -495,8 +494,7 @@ public class GameScreen extends Screen {
 		if(player2 != null){
 			DrawManagerImpl.drawBulletSpeed2P(this, player2.getBulletSpeed());
 			DrawManagerImpl.drawSpeed2P(this, player2.getSpeed());
-//			DrawManagerImpl.drawLives2P(this, ((TwoPlayerMode) this).getLivestwo());
-			drawManager.drawLives(this, ((TwoPlayerMode) this).getLivestwo());
+			DrawManagerImpl.drawLives2P(this, ((TwoPlayerMode) this).getLivestwo());
 		} // by HUD team HyunWoo
 
 		// Countdown to game start.

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -61,7 +61,7 @@ public class GameScreen extends Screen {
 	private EnemyShipFormation enemyShipFormation;
 	/** Player's ship. */
 	private Ship ship;
-	public static Ship player2;
+	public Ship player2;
 	/** Bonus enemy ship that appears sometimes. */
 	private EnemyShip enemyShipSpecial;
 	/** Minimum time between bonus ship appearances. */
@@ -374,11 +374,11 @@ public class GameScreen extends Screen {
 			}
 
 			// Player 2 bullet collision handling
-			TwoPlayerMode.handleBulletCollisionsForPlayer2(this.bullets);
+			TwoPlayerMode.handleBulletCollisionsForPlayer2(this.bullets, player2);
 
 			// 장애물과 아이템 상호작용 추가
-			TwoPlayerMode.handleObstacleCollisionsForPlayer2(this.obstacles);
-			TwoPlayerMode.handleItemCollisionsForPlayer2();
+			TwoPlayerMode.handleObstacleCollisionsForPlayer2(this.obstacles, player2);
+			TwoPlayerMode.handleItemCollisionsForPlayer2(player2);
 		}
 		draw();
 

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -27,6 +27,7 @@ import inventory_develop.*;
 // Sound Operator
 import Sound_Operator.SoundManager;
 import clove.ScoreManager;    // CLOVE
+import twoplayermode.TwoPlayerMode;
 
 
 /**
@@ -60,7 +61,7 @@ public class GameScreen extends Screen {
 	private EnemyShipFormation enemyShipFormation;
 	/** Player's ship. */
 	private Ship ship;
-	public Ship player2;
+	public static Ship player2;
 	/** Bonus enemy ship that appears sometimes. */
 	private EnemyShip enemyShipSpecial;
 	/** Minimum time between bonus ship appearances. */
@@ -72,7 +73,7 @@ public class GameScreen extends Screen {
 	/** Set of all bullets fired by on screen ships. */
 	public Set<PiercingBullet> bullets; //by Enemy team
 	/** Add an itemManager Instance */
-	public ItemManager itemManager; //by Enemy team
+	public static ItemManager itemManager; //by Enemy team
 	/** Shield item */
 	private ItemBarrierAndHeart item;	// team Inventory
 	private FeverTimeItem feverTimeItem;
@@ -356,6 +357,29 @@ public class GameScreen extends Screen {
 		cleanBullets();
 		cleanObstacles();
 		this.itemManager.cleanItems(); //by Enemy team
+
+		if (player2 != null) {
+			// Player 2 movement and shooting
+			boolean moveRight2 = inputManager.isKeyDown(KeyEvent.VK_C);
+			boolean moveLeft2 = inputManager.isKeyDown(KeyEvent.VK_Z);
+
+			if (moveRight2 && player2.getPositionX() + player2.getWidth() < width) {
+				player2.moveRight();
+			}
+			if (moveLeft2 && player2.getPositionX() > 0) {
+				player2.moveLeft();
+			}
+			if (inputManager.isKeyDown(KeyEvent.VK_X)) {
+				player2.shoot(bullets);
+			}
+
+			// Player 2 bullet collision handling
+			TwoPlayerMode.handleBulletCollisionsForPlayer2(this.bullets);
+
+			// 장애물과 아이템 상호작용 추가
+			TwoPlayerMode.handleObstacleCollisionsForPlayer2(this.obstacles);
+			TwoPlayerMode.handleItemCollisionsForPlayer2();
+		}
 		draw();
 
 		/**
@@ -462,10 +486,16 @@ public class GameScreen extends Screen {
 		DrawManagerImpl.drawRemainingEnemies(this, getRemainingEnemies()); // by HUD team SeungYun
 		DrawManagerImpl.drawLevel(this, this.level);
 		DrawManagerImpl.drawBulletSpeed(this, ship.getBulletSpeed());
-		//		Call the method in DrawManagerImpl - Lee Hyun Woo TeamHud
+		// Call the method in DrawManagerImpl - Lee Hyun Woo TeamHud
 		DrawManagerImpl.drawTime(this, this.playTime);
 		// Call the method in DrawManagerImpl - Soomin Lee / TeamHUD
 		drawManager.drawItem(this); // HUD team - Jo Minseo
+
+		if(player2 != null){
+			DrawManagerImpl.drawBulletSpeed2P(this, player2.getBulletSpeed());
+			DrawManagerImpl.drawSpeed2P(this, player2.getSpeed());
+			DrawManagerImpl.drawLives2P(this, ((TwoPlayerMode) this).getLivestwo());
+		} // by HUD team HyunWoo
 
 		// Countdown to game start.
 		if (!this.inputDelay.checkFinished()) {
@@ -750,7 +780,7 @@ public class GameScreen extends Screen {
 	 *            Second entity, the ship.
 	 * @return Result of the collision test.
 	 */
-	public boolean checkCollision(final Entity a, final Entity b) {
+	public static boolean checkCollision(final Entity a, final Entity b) {
 		// Calculate center point of the entities in both axis.
 		int centerAX = a.getPositionX() + a.getWidth() / 2;
 		int centerAY = a.getPositionY() + a.getHeight() / 2;
@@ -786,12 +816,7 @@ public class GameScreen extends Screen {
 	public void setLives(int lives) {
 		this.lives = lives;
 	}
-	public int getLivestwo() {
-		return livestwo;
-	}
-	public void setLivestwo(int livestwo) {
-		this.livestwo = livestwo;
-	}
+
 	public Ship getShip() {
 		return ship;
 	}	// Team Inventory(Item)

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -481,7 +481,8 @@ public class GameScreen extends Screen {
 //		drawManager.drawScore(this, this.scoreManager.getAccumulatedScore());    //clove -> edit by jesung ko - TeamHUD(to udjust score)
 //		drawManager.drawScore(this, this.score); // by jesung ko - TeamHUD
 		DrawManagerImpl.drawScore2(this,this.scoreManager.getAccumulatedScore()); // by jesung ko - TeamHUD
-		drawManager.drawLives(this, this.lives);
+//		drawManager.drawLives(this, this.lives);
+		DrawManagerImpl.drawLives2P(this, this.lives);
 		drawManager.drawHorizontalLine(this, SEPARATION_LINE_HEIGHT - 1);
 		DrawManagerImpl.drawRemainingEnemies(this, getRemainingEnemies()); // by HUD team SeungYun
 		DrawManagerImpl.drawLevel(this, this.level);
@@ -494,7 +495,8 @@ public class GameScreen extends Screen {
 		if(player2 != null){
 			DrawManagerImpl.drawBulletSpeed2P(this, player2.getBulletSpeed());
 			DrawManagerImpl.drawSpeed2P(this, player2.getSpeed());
-			DrawManagerImpl.drawLives2P(this, ((TwoPlayerMode) this).getLivestwo());
+//			DrawManagerImpl.drawLives2P(this, ((TwoPlayerMode) this).getLivestwo());
+			drawManager.drawLives(this, ((TwoPlayerMode) this).getLivestwo());
 		} // by HUD team HyunWoo
 
 		// Countdown to game start.

--- a/src/twoplayermode/TwoPlayerMode.java
+++ b/src/twoplayermode/TwoPlayerMode.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.HashSet;
 
 import Enemy.*;
+import HUDTeam.DrawManagerImpl;
 import screen.GameScreen;
 import engine.GameState;
 import engine.GameSettings;
@@ -26,7 +27,7 @@ import Sound_Operator.SoundManager;
 public class TwoPlayerMode extends GameScreen {
 
 
-    public int livestwo = 3;
+    public static int livestwo = 3;
 
 
     public TwoPlayerMode(GameState gameState, GameSettings gameSettings, boolean bonusLife, int width, int height, int fps) {
@@ -44,39 +45,39 @@ public class TwoPlayerMode extends GameScreen {
         this.player2 = new Ship(this.width / 4, this.height - 30);
     }
 
-    @Override
-    protected void update() {
-        super.update(); // GameScreen의 기존 기능을 사용
-
-        if (player2 != null) {
-            // Player 2 movement and shooting
-            boolean moveRight2 = inputManager.isKeyDown(KeyEvent.VK_C);
-            boolean moveLeft2 = inputManager.isKeyDown(KeyEvent.VK_Z);
-
-            if (moveRight2 && player2.getPositionX() + player2.getWidth() < width) {
-                player2.moveRight();
-            }
-            if (moveLeft2 && player2.getPositionX() > 0) {
-                player2.moveLeft();
-            }
-            if (inputManager.isKeyDown(KeyEvent.VK_X)) {
-                player2.shoot(bullets);
-            }
-
-            // Player 2 bullet collision handling
-            handleBulletCollisionsForPlayer2();
-
-            // 장애물과 아이템 상호작용 추가
-            handleObstacleCollisionsForPlayer2();
-            handleItemCollisionsForPlayer2();
-        }
-    }
+//    @Override
+//    protected void update() {
+//        super.update(); // GameScreen의 기존 기능을 사용
+//
+////        if (player2 != null) {
+////            // Player 2 movement and shooting
+////            boolean moveRight2 = inputManager.isKeyDown(KeyEvent.VK_C);
+////            boolean moveLeft2 = inputManager.isKeyDown(KeyEvent.VK_Z);
+////
+////            if (moveRight2 && player2.getPositionX() + player2.getWidth() < width) {
+////                player2.moveRight();
+////            }
+////            if (moveLeft2 && player2.getPositionX() > 0) {
+////                player2.moveLeft();
+////            }
+////            if (inputManager.isKeyDown(KeyEvent.VK_X)) {
+////                player2.shoot(bullets);
+////            }
+////
+////            // Player 2 bullet collision handling
+////            handleBulletCollisionsForPlayer2();
+////
+////            // 장애물과 아이템 상호작용 추가
+////            handleObstacleCollisionsForPlayer2();
+////            handleItemCollisionsForPlayer2();
+////        }
+//    }
 
     // Player 2의 총알과 충돌 처리
-    private void handleBulletCollisionsForPlayer2() {
+    public static void handleBulletCollisionsForPlayer2( Set<PiercingBullet> bullets) {
         if(player2==null) return;
         Set<Bullet> recyclable = new HashSet<>();
-        for (Bullet bullet : this.bullets) {
+        for (Bullet bullet : bullets) {
             if (bullet.getSpeed() > 0 && checkCollision(bullet, player2)) {
                 recyclable.add(bullet);
                 if (!player2.isDestroyed()) {
@@ -90,14 +91,14 @@ public class TwoPlayerMode extends GameScreen {
                 }
             }
         }
-        this.bullets.removeAll(recyclable);
+        bullets.removeAll(recyclable);
         BulletPool.recycle(recyclable);
     }
 
     // Player 2의 장애물과 충돌 처리
-    private void handleObstacleCollisionsForPlayer2() {
+    public static void handleObstacleCollisionsForPlayer2(Set<Obstacle> obstacles) {
         if(player2==null) return;
-        for (Obstacle obstacle : this.obstacles) {
+        for (Obstacle obstacle : obstacles) {
             if (!obstacle.isDestroyed() && checkCollision(player2, obstacle)) {
                 livestwo--;
                 if (!player2.isDestroyed()) {
@@ -115,7 +116,7 @@ public class TwoPlayerMode extends GameScreen {
     }
 
     // Player 2의 아이템과 충돌 처리
-    private void handleItemCollisionsForPlayer2() {
+    public static void handleItemCollisionsForPlayer2() {
         if(player2==null) return;
         for (Item item : itemManager.items) {
             if (checkCollision(item, player2)) {
@@ -125,14 +126,16 @@ public class TwoPlayerMode extends GameScreen {
         }
     }
 
-    @Override
-    public void draw() {
-
-
-
-        super.draw(); // GameScreen의 기존 기능을 사용
-
-
+    /**
+     *
+     * */
+    public static int getLivestwo() {
+        return livestwo;
     }
+
+    public void setLivestwo(int livestwo) {
+        this.livestwo = livestwo;
+    }
+
 }
 

--- a/src/twoplayermode/TwoPlayerMode.java
+++ b/src/twoplayermode/TwoPlayerMode.java
@@ -74,7 +74,7 @@ public class TwoPlayerMode extends GameScreen {
 //    }
 
     // Player 2의 총알과 충돌 처리
-    public static void handleBulletCollisionsForPlayer2( Set<PiercingBullet> bullets) {
+    public static void handleBulletCollisionsForPlayer2( Set<PiercingBullet> bullets, Ship player2) {
         if(player2==null) return;
         Set<Bullet> recyclable = new HashSet<>();
         for (Bullet bullet : bullets) {
@@ -96,7 +96,7 @@ public class TwoPlayerMode extends GameScreen {
     }
 
     // Player 2의 장애물과 충돌 처리
-    public static void handleObstacleCollisionsForPlayer2(Set<Obstacle> obstacles) {
+    public static void handleObstacleCollisionsForPlayer2(Set<Obstacle> obstacles, Ship player2) {
         if(player2==null) return;
         for (Obstacle obstacle : obstacles) {
             if (!obstacle.isDestroyed() && checkCollision(player2, obstacle)) {
@@ -116,7 +116,7 @@ public class TwoPlayerMode extends GameScreen {
     }
 
     // Player 2의 아이템과 충돌 처리
-    public static void handleItemCollisionsForPlayer2() {
+    public static void handleItemCollisionsForPlayer2(Ship player2) {
         if(player2==null) return;
         for (Item item : itemManager.items) {
             if (checkCollision(item, player2)) {


### PR DESCRIPTION
## What
This PR adds updated the ability to display 2P's status information on the game screen:
- The life of 2P is displayed in the upper right corner with a blue heart.
- The bullet firing speed of 2P is shown in the lower right.
- The speed of movement of the 2P is shown in the lower right.
- One of the TwoPlayMode class method's logic was modified to the parent class's method to resolve an in-game error.

## Why
We have added these features for the user's convenience in gaming in 2P.

## Related Issue
Closes #46

## How to Test
1. Test the program in a local environment and tested it


## Screenshots
![image](https://github.com/user-attachments/assets/217a3ece-679d-4d1f-9d6a-4da750ab772d)

- added 2p's status information

![image](https://github.com/user-attachments/assets/a7ba9afe-effc-4402-a956-da6423588b7d)

- 2p status change test completed


## Additional information
-The following error was found.
1. 1P's life increases when 2P eats life items.
2. When 2P dies, 2P's ship does not disappear, and 2P can also participate in the game.
3. When 1P dies, an error occurs and the screen stops.   
![image](https://github.com/user-attachments/assets/ff608dfe-558b-4ca3-bfb5-c1a105756bcc)
```
Exception in thread "main" java.lang.NumberFormatException: For input string: "PAT"
   at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
   at java.base/java.lang.Long.parseLong(Long.java:618)
   at java.base/java.lang.Long.parseLong(Long.java:722)
   at engine.FileManager.loadHighScores(FileManager.java:210)
   at screen.ScoreScreen.<init>(ScoreScreen.java:109)
   at engine.Core.main(Core.java:357)
```
4. The game is played even though the two players have no life.
![image](https://github.com/user-attachments/assets/015a65e6-57a1-4d58-bf79-d9311a84945b)
